### PR TITLE
Catch empty responses

### DIFF
--- a/index.php
+++ b/index.php
@@ -50,6 +50,18 @@ if ($text == "help")
 		{ // OK
 		$js = json_decode($result, true);
 
+                if ($js['positives'] == "")
+                {// Results not yet available
+                $php_array = array(
+                                'response_type' => 'ephemeral',
+                                'text' => "No recent results for this URL. Scanning will take place automatically. Please try again in 5 minutes."
+                );
+                $reply = json_encode($php_array);
+                }
+                else
+                {
+
+
 		// make json reply
 
 		$php_array = array(
@@ -62,6 +74,7 @@ if ($text == "help")
                 . " scanners. \n \n " . $js['permalink']
 		);
 		$reply = json_encode($php_array);
+		}
 		}
 	  else
 		{ // Error occured

--- a/index.php
+++ b/index.php
@@ -66,12 +66,8 @@ if ($text == "help")
 	  else
 		{ // Error occured
 		$php_array = array(
-			array(
-				'response_type' => 'ephemeral'
-			) ,
-			array(
+				'response_type' => 'ephemeral',
 				'text' => "Sorry, that didn't work. Please try again."
-			)
 		);
 		$reply = json_encode($php_array);
 		}

--- a/index.php
+++ b/index.php
@@ -50,7 +50,7 @@ if ($text == "help")
 		{ // OK
 		$js = json_decode($result, true);
 
-                if ($js['positives'] == "")
+                if (strlen($js['positives']) == 0)
                 {// Results not yet available
                 $php_array = array(
                                 'response_type' => 'ephemeral',


### PR DESCRIPTION
When a new, previously unseen URL is submitted to VirusTotal, it responds with an empty value and queues it for a scan.  This is confusing to endusers.  Added simple logic to handle empty responses.

Also fixed a bug with error test array construction.